### PR TITLE
Add base UI components and update HomeScreen

### DIFF
--- a/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzBackgroundBox.kt
+++ b/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzBackgroundBox.kt
@@ -1,0 +1,19 @@
+package com.netanel.pawzplay.baseUI
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.netanel.pawzplay.theme.LocalPawzColors
+
+@Composable
+fun PawzBackgroundBox(content: @Composable () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(LocalPawzColors.current.background)
+    ) {
+        content()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzButton.kt
+++ b/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzButton.kt
@@ -1,0 +1,27 @@
+package com.netanel.pawzplay.baseUI
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.netanel.pawzplay.theme.LocalPawzColors
+
+@Composable
+fun PawzButton(
+    onClick: () -> Unit,
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    val colors = LocalPawzColors.current
+    Button(
+        onClick = onClick,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = colors.primary,
+            contentColor = colors.onPrimary
+        ),
+        modifier = modifier
+    ) {
+        Text(text)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzCard.kt
+++ b/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzCard.kt
@@ -1,0 +1,30 @@
+package com.netanel.pawzplay.baseUI
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.netanel.pawzplay.theme.LocalPawzColors
+
+@Composable
+fun PawzCard(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val colors = LocalPawzColors.current
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = colors.background,
+            contentColor = colors.onBackground
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            content()
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzSurface.kt
+++ b/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzSurface.kt
@@ -1,0 +1,21 @@
+package com.netanel.pawzplay.baseUI
+
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.netanel.pawzplay.theme.LocalPawzColors
+
+@Composable
+fun PawzSurface(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    val colors = LocalPawzColors.current
+    Surface(
+        modifier = modifier,
+        color = colors.background,
+        contentColor = colors.onBackground
+    ) {
+        content()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzText.kt
+++ b/shared/src/commonMain/kotlin/com/netanel/pawzplay/baseUI/PawzText.kt
@@ -1,0 +1,26 @@
+package com.netanel.pawzplay.baseUI
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import com.netanel.pawzplay.theme.LocalPawzColors
+
+@Composable
+fun PawzText(
+    text: String,
+    modifier: Modifier = Modifier,
+    fontSize: TextUnit = 16.sp,
+    fontWeight: FontWeight = FontWeight.Normal
+) {
+    val colors = LocalPawzColors.current
+    Text(
+        text = text,
+        color = colors.onBackground,
+        modifier = modifier,
+        fontSize = fontSize,
+        fontWeight = fontWeight
+    )
+}

--- a/shared/src/commonMain/kotlin/com/netanel/pawzplay/home/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/netanel/pawzplay/home/HomeScreen.kt
@@ -5,15 +5,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.netanel.pawzplay.baseUI.PawzText
 import com.netanel.pawzplay.theme.ColorProfile
-import com.netanel.pawzplay.theme.LocalPawzColors
 import com.netanel.pawzplay.theme.ThemeController
 
 @Composable
@@ -21,7 +20,7 @@ fun HomeScreen() {
     val isCatVision by remember { derivedStateOf { ThemeController.theme.value == ColorProfile.CatVision } }
 
     Column(modifier = Modifier.padding(16.dp)) {
-        Text("Welcome to PawzPlay 🐾", color = LocalPawzColors.current.primary)
+        PawzText("Welcome to PawzPlay 🐾")
 
         Spacer(modifier = Modifier.height(16.dp))
 


### PR DESCRIPTION
Introduced reusable base UI components: PawzBackgroundBox, PawzButton, PawzCard, PawzSurface, and PawzText for consistent theming and structure. Updated HomeScreen to use PawzText instead of Text for improved style consistency.